### PR TITLE
update es3ify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FIS3 transform to convert ES5 syntax to be ES3-compatible",
   "main": "index.js",
   "dependencies": {
-    "es3ify": "^0.1.4"
+    "es3ify": "^0.2.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
es3ify v0.1.4 依赖的`"esprima-fb": "~3001.0001.0000-dev-harmony-fb"`在编译时时`semver`会报错。
`^0.1.4`表示`>=0.1.4 <0.2.0`, 不能自动更新到最新版本
